### PR TITLE
Fix regext at setup.sh

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -264,7 +264,7 @@ case "$response" in
         while [ 1 ]; do
             kubectlout=$(kubectl --context $CLUSTER_PREFIX$primary_region-01 get job spannerdemo-venuesload)
 
-            regex="spannerdemo-venuesload[[:space:]]+([0-9]*)[[:space:]]+([0-9]*)"
+            regex="spannerdemo-venuesload[[:space:]]+([0-9]*)/+([0-9]*)[[:space:]]+([0-9]*)"
             if [[ $kubectlout =~ $regex ]];
             then
                 echo "checking if venues load job is finished..."
@@ -285,7 +285,7 @@ case "$response" in
         while [ 1 ]; do
             kubectlout=$(kubectl --context $CLUSTER_PREFIX$primary_region-01 get job spannerdemo-ticketsload)
 
-            regex="spannerdemo-ticketsload[[:space:]]+([0-9]*)[[:space:]]+([0-9]*)"
+            regex="spannerdemo-ticketsload[[:space:]]+([0-9]*)/+([0-9]*)[[:space:]]+([0-9]*)"
             if [[ $kubectlout =~ $regex ]];
             then
                 echo "checking if ticket load job is finished..."


### PR DESCRIPTION
kubectlout is 
'NAME                     COMPLETIONS   DURATION   AGE
spannerdemo-venuesload   0/2           14s        47m'

So the regex was incorrectly used once we need to look at COMPLETIONS: 0/2